### PR TITLE
Added New Implementations

### DIFF
--- a/src/SVega9848/GlobalToast/Commands/GlobalToastCommand.php
+++ b/src/SVega9848/GlobalToast/Commands/GlobalToastCommand.php
@@ -15,31 +15,63 @@ class GlobalToastCommand extends Command implements PluginOwned {
 
     private Main $main;
 
-    public function __construct(Main $main)
-    {
-        $this->main = $main;
+    public function __construct(Main $main) {
         parent::__construct("globaltoast", "Broadcast toast announcements to everyone in the server!");
+        $this->main = $main;
+        $this->setPermission("globaltoast.use");
     }
 
-    public function execute(CommandSender $sender, string $commandLabel, array $args)
-    {
-        $plugin = $this->getOwningPlugin();
-        if($sender instanceof Player) {
-            if($sender->hasPermission("globaltoast.cmd")) {
-                if(isset($args[0])) {
-                    foreach($plugin->getServer()->getOnlinePlayers() as $player) {
-                        $packet = ToastRequestPacket::create(TextFormat::colorize($this->main->config->get("toast-title")), TextFormat::colorize(implode(" ", $args)));
-                        $player->getNetworkSession()->sendDataPacket($packet);
-                    }
-                } else {
-                    $sender->sendMessage(TextFormat::colorize("&7[&c!&7] &cYou must type someting! Example: /globaltoast (message)"));
+    public function execute(CommandSender $sender, string $commandLabel, array $args): bool {
+        if (!$this->testPermission($sender)) {
+            return true;
+        }
+
+        if (empty($args)) {
+            $sender->sendMessage(TextFormat::colorize("&7[&c!&7] &cYou must type something! Example: /globaltoast <message> [player]"));
+            return true;
+        }
+
+        $message = implode(" ", $args);
+        $targetPlayer = null;
+
+        if (isset($args[count($args) - 1])) {
+            $targetName = array_pop($args);
+
+            if (strtolower($targetName) === "everyone") {
+                $targetPlayer = "everyone";
+            } else {
+                $targetPlayer = $this->main->getServer()->getPlayerExact($targetName);
+
+                if ($targetPlayer === null) {
+                    $sender->sendMessage(TextFormat::colorize("&7[&c!&7] &cThe specified player is not online."));
+                    return true;
                 }
             }
+        } elseif ($sender instanceof Player) {
+            $targetPlayer = $sender;
+        } else {
+            $sender->sendMessage(TextFormat::colorize("&7[&c!&7] &cYou must specify a player when running this command from the console."));
+            return true;
         }
+
+        $packet = new ToastRequestPacket();
+        $packet->title = TextFormat::colorize($this->main->getConfig()->get("toast-title"));
+        $packet->subtitle = TextFormat::colorize($message);
+
+        if ($targetPlayer === "everyone") {
+            foreach ($this->main->getServer()->getOnlinePlayers() as $player) {
+                $player->getNetworkSession()->sendDataPacket(clone $packet);
+            }
+        } else {
+            $targetPlayer->getNetworkSession()->sendDataPacket($packet);
+        }
+
+        $sender->sendMessage(TextFormat::colorize("&7[&a!&7] &aToast has been sent."));
+
+        return true;
     }
 
-    public function getOwningPlugin(): Plugin
-    {
+    public function getOwningPlugin(): Plugin {
         return $this->main;
     }
 }


### PR DESCRIPTION
Added permission: The command now requires the `globaltoast.use` permission to be executed.

Improved error handling: The code now checks for various error conditions, such as empty arguments, invalid target player, and console usage.

Added target player option: You can specify a target player as the last argument in the command. If a target player is specified, the toast will only be visible to that player. If no target player is specified, the toast will be visible to the executor.

Added "everyone" option: If the target player option is set to "everyone" (case-insensitive), the global toast will be sent to everyone in the server. This is achieved by cloning the ToastRequestPacket and sending it to each online player.

Updated the target player handling: If the target player option is set to "everyone", the code iterates over each online player to send the cloned packet. Otherwise, it sends the packet to the specified target player.